### PR TITLE
feat(logging): relocate log file to user data dir

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -143,10 +143,10 @@ next to your config or plugin:
 {
   "runtime.version": "LuaJIT",
   "workspace.library": [
-    "%APPDATA%/hollow/types",  // Windows
-    "~/.config/hollow/types",  // Linux/macOS
-    "/mnt/c/Users/YOUR_USER/AppData/Roaming/hollow/types" // WSL
-  ]
+    "%APPDATA%/hollow/types", // Windows
+    "~/.config/hollow/types", // Linux/macOS
+    "/mnt/c/Users/YOUR_USER/AppData/Roaming/hollow/types", // WSL
+  ],
 }
 ```
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -54,9 +54,9 @@ After a user unpacks a release and runs `hollow.exe` once:
   hollow-cli                  # Python client, if shipped
   conf/
     init.lua                  # shipped base, if shipped
-  hollow.log                  # log file, written next to the executable
   %APPDATA%\hollow\
     init.lua                  # user override (does not exist by default)
+    hollow.log                # log file
     plugins\                  # cloned git plugins
     layouts\                  # named workspace layouts
       default.json
@@ -124,8 +124,8 @@ To symbolicate a user-reported crash:
    from the same source tree.
 2. Capture `hollow.pdb`, `hollow-gui.pdb`, and `hollow-native.pdb`
    from `zig-out/bin/`.
-3. Ask the user for `hollow.log` from the install dir.
-4. Resolve addresses from `hollow.log` against the matching PDB.
+3. Ask the user for `%APPDATA%\hollow\hollow.log`.
+4. Resolve addresses from `%APPDATA%\hollow\hollow.log` against the matching PDB.
 
 The log file records panics, including the error return trace and the
 host stack trace, written by `src/main.zig:panic`. The matching PDB

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -11,6 +11,8 @@
 - The default `unix` domain uses `$SHELL`, with `/bin/sh` as fallback.
 - Config files use the same syntax as Windows; user config lives at
   `$XDG_CONFIG_HOME/hollow/init.lua` or `$HOME/.config/hollow/init.lua`.
+- Logs live at `$XDG_DATA_HOME/hollow/hollow.log` or
+  `$HOME/.local/share/hollow/hollow.log`.
 - `window_titlebar_show = false` uses X11 window-manager hints. Top-bar drag
   and edge/corner resize work on window managers and XWayland compositors that
   allow client-managed windows.

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -28,8 +28,9 @@ For crash symbolication, see
 
 ## Runtime layout
 
-`hollow.exe` is a thin console launcher; it parses flags, opens
-`hollow.log`, then spawns `hollow-native.exe` (the GUI) as a sibling.
+`hollow.exe` is a thin console launcher; it parses flags, then spawns
+`hollow-native.exe` (the GUI) as a sibling. The GUI appends to
+`%APPDATA%\hollow\hollow.log`.
 The console returns immediately so the terminal you launched from is
 not blocked.
 
@@ -46,7 +47,7 @@ hollow.exe
 | Bundled base config | `conf/init.lua` next to the executable |
 | Personal override   | `%APPDATA%\hollow\init.lua`            |
 | Explicit override   | `--config path\to\init.lua`            |
-| Log file            | `hollow.log` next to the executable    |
+| Log file            | `%APPDATA%\hollow\hollow.log`         |
 | Data dir (plugins)  | `%APPDATA%\hollow`                     |
 
 The base config is loaded first, the override is merged on top.
@@ -102,12 +103,11 @@ The most useful Windows-specific flags:
 
 ## Debugging
 
-- `hollow.log` is written next to the executable; every panic and
-  every log line lands there.
+- `%APPDATA%\hollow\hollow.log` receives every panic and log line.
 - The shipped base config sets `debug_overlay = false` and
   `command_timing = false`. Flip them on in your personal config to
   get the on-screen overlay.
-- For crash reports, send `hollow.log`; symbolication requires a
+- For crash reports, send `%APPDATA%\hollow\hollow.log`; symbolication requires a
   build with matching PDBs as described in
   [Packaging → Crash reports](../packaging.md#crash-reports).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -131,8 +131,7 @@ give it.
 | `setup()` throws | Logged with traceback, loader continues |
 | Local path missing | Logged, plugin skipped |
 
-The loader never panics. Errors are visible in `hollow.log` next to
-the executable.
+The loader never panics. Errors are visible in the host log.
 
 ## See also
 

--- a/docs/reference/lua/overview.md
+++ b/docs/reference/lua/overview.md
@@ -66,8 +66,10 @@ hollow.log("starting up", some_value)
 hollow.inspect({ a = 1, b = 2 })
 ```
 
-`hollow.log` writes to the host log (and `hollow.log` next to the
-executable). `hollow.inspect` returns a pretty-printed string.
+`hollow.log` writes to the host log. On Windows, this is
+`%APPDATA%\hollow\hollow.log`; on Linux, it is
+`$XDG_DATA_HOME/hollow/hollow.log` or `$HOME/.local/share/hollow/hollow.log`.
+`hollow.inspect` returns a pretty-printed string.
 
 ## Filesystem helpers
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -196,9 +196,12 @@ require name).
 
 ## Logs
 
-- `hollow.log` — written next to the executable; every panic, every
+- Windows: `%APPDATA%\hollow\hollow.log` receives every panic and
   `std.log.*` line.
-- `hollow.log` is truncated on each startup.
+- Linux: `$XDG_DATA_HOME/hollow/hollow.log` or
+  `$HOME/.local/share/hollow/hollow.log`.
+- macOS: `hollow.log` is written next to the executable.
+- Logs append across startups and concurrent GUI processes.
 - For crash reports, send the log; symbolication requires a
   build with matching PDBs as described in
   [Packaging → Crash reports](packaging.md#crash-reports).

--- a/scripts/trace-terminal.sh
+++ b/scripts/trace-terminal.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 REPO_DIR="$(readlink -f "$SCRIPT_DIR/..")"
-LOG_PATH="$REPO_DIR/hollow.log"
+if [[ -n "${APPDATA:-}" ]]; then
+  LOG_PATH="$APPDATA/hollow/hollow.log"
+elif [[ -n "${USERPROFILE:-}" ]]; then
+  LOG_PATH="$USERPROFILE/AppData/Roaming/hollow/hollow.log"
+else
+  LOG_PATH="$REPO_DIR/zig-out/bin/hollow.log"
+fi
 
 rm -f "$LOG_PATH"
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,7 @@ const build_options = @import("build_options");
 const native_cli = @import("native_cli.zig");
 const font_config = @import("render/font_config.zig");
 const io = @import("io.zig");
+const platform = @import("platform.zig");
 
 const win32 = if (builtin.os.tag == .windows) struct {
     const BOOL = i32;
@@ -16,8 +17,11 @@ const win32 = if (builtin.os.tag == .windows) struct {
 
     pub extern "kernel32" fn AttachConsole(dwProcessId: DWORD) callconv(.winapi) BOOL;
     pub extern "kernel32" fn CreateProcessW(lpApplicationName: ?LPWSTR, lpCommandLine: ?LPWSTR, lpProcessAttributes: ?*SECURITY_ATTRIBUTES, lpThreadAttributes: ?*SECURITY_ATTRIBUTES, bInheritHandles: BOOL, dwCreationFlags: DWORD, lpEnvironment: ?*anyopaque, lpCurrentDirectory: ?LPWSTR, lpStartupInfo: *STARTUPINFOW, lpProcessInformation: *PROCESS_INFORMATION) callconv(.winapi) BOOL;
+    pub extern "kernel32" fn CreateMutexW(lpMutexAttributes: ?*SECURITY_ATTRIBUTES, bInitialOwner: BOOL, lpName: ?[*:0]const u16) callconv(.winapi) HANDLE;
     pub extern "kernel32" fn GetStdHandle(nStdHandle: DWORD) callconv(.winapi) HANDLE;
     pub extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(.winapi) BOOL;
+    pub extern "kernel32" fn ReleaseMutex(hMutex: HANDLE) callconv(.winapi) BOOL;
+    pub extern "kernel32" fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) callconv(.winapi) DWORD;
 
     const LPWSTR = [*:0]u16;
     const SECURITY_ATTRIBUTES = extern struct {
@@ -53,16 +57,78 @@ const win32 = if (builtin.os.tag == .windows) struct {
     };
 
     const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
+    const INFINITE: DWORD = 0xFFFF_FFFF;
+    const WAIT_ABANDONED: DWORD = 0x0000_0080;
+    const WAIT_OBJECT_0: DWORD = 0x0000_0000;
 } else struct {};
 
 var g_log_file: ?std.Io.File = null;
+var g_log_named_mutex: ?*anyopaque = null;
 var g_log_mutex: std.Io.Mutex = .init;
 threadlocal var g_log_recursion_depth: usize = 0;
+const LogLock = enum { none, file, named_mutex };
 
 pub const std_options: std.Options = .{
     .logFn = fileLogFn,
     .enable_segfault_handler = true,
 };
+
+fn initLogProcessLock() void {
+    if (comptime builtin.os.tag == .windows) {
+        g_log_named_mutex = win32.CreateMutexW(null, 0, std.unicode.utf8ToUtf16LeStringLiteral("Local\\HollowLog"));
+    }
+}
+
+fn deinitLogProcessLock() void {
+    if (comptime builtin.os.tag == .windows) {
+        if (g_log_named_mutex) |mutex| _ = win32.CloseHandle(mutex);
+        g_log_named_mutex = null;
+    }
+}
+
+fn lockLogFile(file: std.Io.File) LogLock {
+    if (comptime builtin.os.tag == .windows) {
+        const mutex = g_log_named_mutex orelse return .none;
+        const result = win32.WaitForSingleObject(mutex, win32.INFINITE);
+        if (result == win32.WAIT_OBJECT_0 or result == win32.WAIT_ABANDONED) return .named_mutex;
+        return .none;
+    }
+    file.lock(io.get(), .exclusive) catch return .none;
+    return .file;
+}
+
+fn unlockLogFile(file: std.Io.File, lock: LogLock) void {
+    switch (lock) {
+        .none => {},
+        .file => file.unlock(io.get()),
+        .named_mutex => {
+            if (comptime builtin.os.tag == .windows) {
+                if (g_log_named_mutex) |mutex| {
+                    _ = win32.ReleaseMutex(mutex);
+                }
+            }
+        },
+    }
+}
+
+fn seekLogWriterToEnd(file: std.Io.File, writer: *std.Io.File.Writer) bool {
+    const stat = file.stat(io.get()) catch return false;
+    writer.seekTo(stat.size) catch return false;
+    return true;
+}
+
+fn openLogFile() ?std.Io.File {
+    const allocator = std.heap.page_allocator;
+    const log_dir = if (builtin.os.tag == .windows or builtin.os.tag == .linux)
+        platform.userDataDir(allocator) catch return null
+    else
+        platform.selfExeDir(allocator) catch return null;
+    defer allocator.free(log_dir);
+    std.Io.Dir.cwd().createDirPath(io.get(), log_dir) catch {};
+    const log_path = std.fs.path.join(allocator, &.{ log_dir, "hollow.log" }) catch return null;
+    defer allocator.free(log_path);
+    return std.Io.Dir.createFileAbsolute(io.get(), log_path, .{ .read = true, .truncate = false }) catch null;
+}
 
 fn writeLogLine(prefix: []const u8, text: []const u8) void {
     if (g_log_file) |f| {
@@ -77,8 +143,11 @@ fn writeLogLine(prefix: []const u8, text: []const u8) void {
             g_log_recursion_depth -= 1;
             if (needs_lock) g_log_mutex.unlock(io.get());
         }
+        const log_lock = if (needs_lock) lockLogFile(f) else .none;
+        defer unlockLogFile(f, log_lock);
         var buf: [1024]u8 = undefined;
         var w = f.writer(io.get(), &buf);
+        if (!seekLogWriterToEnd(f, &w)) return;
         w.interface.print("[{s}] {s}\n", .{ prefix, text }) catch {};
         w.interface.flush() catch {};
         f.sync(io.get()) catch {};
@@ -98,8 +167,11 @@ fn writeCurrentStackToLog(start_addr: ?usize) void {
             g_log_recursion_depth -= 1;
             if (needs_lock) g_log_mutex.unlock(io.get());
         }
+        const log_lock = if (needs_lock) lockLogFile(f) else .none;
+        defer unlockLogFile(f, log_lock);
         var buf: [2048]u8 = undefined;
         var w = f.writer(io.get(), &buf);
+        if (!seekLogWriterToEnd(f, &w)) return;
 
         w.interface.writeAll("[panic] stack trace:\n") catch {};
         std.debug.writeCurrentStackTrace(.{ .first_address = start_addr }, .{ .writer = &w.interface, .mode = .no_color }) catch |err| {
@@ -131,13 +203,17 @@ fn fileLogFn(
             g_log_recursion_depth -= 1;
             if (needs_lock) g_log_mutex.unlock(io.get());
         }
+        const log_lock = if (needs_lock) lockLogFile(f) else .none;
+        defer unlockLogFile(f, log_lock);
         var buf: [1024]u8 = undefined;
         var w: std.Io.Writer = .fixed(&buf);
         w.print("[{s}] " ++ format ++ "\n", .{prefix} ++ args) catch {};
         var file_buf: [1024]u8 = undefined;
         var file_writer = f.writer(io.get(), &file_buf);
+        if (!seekLogWriterToEnd(f, &file_writer)) return;
         file_writer.interface.writeAll(w.buffered()) catch {};
         file_writer.interface.flush() catch {};
+        f.sync(io.get()) catch {};
     }
 }
 
@@ -157,8 +233,11 @@ pub fn panic(msg: []const u8, trace: ?*std.builtin.StackTrace, ra: ?usize) noret
                 g_log_recursion_depth -= 1;
                 if (needs_lock) g_log_mutex.unlock(io.get());
             }
+            const log_lock = if (needs_lock) lockLogFile(f) else .none;
+            defer unlockLogFile(f, log_lock);
             var buf: [2048]u8 = undefined;
             var w = f.writer(io.get(), &buf);
+            if (!seekLogWriterToEnd(f, &w)) std.process.abort();
 
             w.interface.writeAll("[panic] error return trace:\n") catch {};
             std.debug.writeErrorReturnTrace(t, .{ .writer = &w.interface, .mode = .no_color }) catch |err| {
@@ -186,8 +265,10 @@ fn guiMain(process_args: std.process.Args) !void {
     const App = @import("app.zig").App;
     const sokol_runtime = @import("render/sokol_runtime.zig");
 
-    // Open log file next to the exe (works even without a console).
-    g_log_file = std.Io.Dir.cwd().createFile(io.get(), "hollow.log", .{ .truncate = true }) catch null;
+    // Open log file before GUI startup (works even without a console).
+    initLogProcessLock();
+    defer deinitLogProcessLock();
+    g_log_file = openLogFile();
     defer if (g_log_file) |f| f.close(io.get());
 
     var gpa: std.heap.DebugAllocator(.{ .thread_safe = true }) = .init;


### PR DESCRIPTION

Move hollow.log off the install directory to the platform user data dir: %APPDATA%\hollow on Windows, $XDG_DATA_HOME/hollow on Linux, next to the exe on macOS. Logs now append across startups and concurrent GUI processes instead of truncating, guarded by a named mutex on Windows and a file lock elsewhere. Update all docs and the trace script to match the new locations.